### PR TITLE
Fix: Correct GIF handling when converting to MP4

### DIFF
--- a/any_to_any.py
+++ b/any_to_any.py
@@ -599,7 +599,7 @@ class AnyToAny:
         for image_path_set in file_paths[Category.IMAGE]:
             # Depending on the format, different fragmentation is required
             if image_path_set[2] == "gif":
-                clip = ImageSequenceClip(self._join_back(image_path_set), fps=24)
+                clip = VideoFileClip(self._join_back(image_path_set), audio=False)
                 # If recursive, create file outright where its source was found
                 if not self.recursive or self.input != self.output:
                     out_path = os.path.abspath(os.path.join(self.output, f"{image_path_set[1]}.{format}"))
@@ -609,7 +609,7 @@ class AnyToAny:
                     out_path,
                     codec=codec,
                     fps=clip.fps if self.framerate is None else self.framerate,
-                    audio=True,
+                    audio=False,
                     logger=self.prog_logger,
                 )
                 clip.close()


### PR DESCRIPTION
## Summary

This PR resolves #4  where converting `.gif` files to `.mp4` using the `-f mp4` option fails with a NotADirectoryError on Windows (and a similar error on Linux too). The root cause was the use of `ImageSequenceClip`, which expects a directory of images, rather than `VideoFileClip`, which properly supports video formats like `.gif`.

### Fix Details

Replaces:

```python
clip = ImageSequenceClip(self._join_back(image_path_set), fps=24)
```

with:

```python
clip = VideoFileClip(self._join_back(image_path_set), audio=False)
```

in `to_movie()`, ensuring that `GIFs` are handled correctly.

### Resolution

This fix allows GIF-to-MP4 conversions to work as expected and aligns the logic with the capabilities of MoviePy. I added the `audio=False` because GIFs don't come with audio.